### PR TITLE
fix(audioteka): search returns no results after markup change

### DIFF
--- a/src/providers/audioteka/utils.ts
+++ b/src/providers/audioteka/utils.ts
@@ -153,17 +153,17 @@ export function extractLabeledArray($: cheerio.CheerioAPI, labels: string[]): st
 
 export function parseSearchResults($: cheerio.CheerioAPI): AudiotekaSearchMatch[] {
   const matches: AudiotekaSearchMatch[] = []
-  const $books = $('.adtk-item.teaser_teaser__FDajW')
+  const $books = $('li[class*="teaser_teaser__"]')
 
   $books.each((_, element) => {
     const $book = $(element)
 
-    const title = $book.find('.teaser_title__hDeCG').text().trim()
-    const bookPath = $book.find('.teaser_link__fxVFQ').attr('href')
+    const title = $book.find('[class*="teaser_title__"]').text().trim()
+    const bookPath = $book.find('[class*="teaser_link__"]').attr('href')
     const bookUrl = bookPath ? BASE_URL + bookPath : ''
-    const author = $book.find('.teaser_author__LWTRi').text().trim()
-    const cover = cleanCoverUrl($book.find('.teaser_coverImage__YMrBt').attr('src'))
-    const rating = parseFloat($book.find('.teaser-footer_rating__TeVOA').text().trim()) || undefined
+    const author = $book.find('[class*="teaser_author__"]').text().trim()
+    const cover = cleanCoverUrl($book.find('[class*="teaser_coverImage__"]').attr('src'))
+    const rating = parseFloat($book.find('[class*="teaser-footer_rating__"]').text().trim()) || undefined
 
     const id = $book.attr('data-item-id') || bookUrl.split('/').pop() || ''
 


### PR DESCRIPTION
## Problem

Every Audioteka search returns `{"matches":[]}`, HTTP 200, no error in the logs:

```
GET /audioteka/lang:pl/search?title=wiedzmin&author=sapkowski
{"matches":[]}
```

Cause is in `parseSearchResults`:

```ts
const $books = $('.adtk-item.teaser_teaser__FDajW')
```

Audioteka dropped the `adtk-item` class from the result list items. The selector requires both classes, so it matches nothing. In the live HTML the item is now just:

```html
<li class="teaser_teaser__FDajW"><a class="teaser_link__fxVFQ" href="/pl/audiobook/krew-elfow-tom-1/">
```

`adtk-item` does not appear anywhere on the page. All the inner CSS-module hashes still match.

## Fix

Match on the CSS-module class prefix rather than the full hashed name, for the result item and for the fields inside it. A frontend rebuild that only changes the hash suffix no longer breaks the parser.

## Verification

Against live HTML from `https://audioteka.com/pl/szukaj/?phrase=wiedzmin`:

- 28 results parsed (0 before the change)
- detail page still yields cover, narrator, duration, publisher, description, genres and series:

```json
{
  "title": "Krew elfów. Tom 1",
  "authors": ["Andrzej Sapkowski"],
  "url": "https://audioteka.com/pl/audiobook/krew-elfow-tom-1/",
  "cover": "https://atkcdn.audioteka.com/cc/c8/krew-elfow-tom-1/947.jpg",
  "narrator": "zespół lektorów",
  "duration": 388,
  "publisher": "SuperNOWA",
  "genres": ["Fantasy", "Fantastyka"],
  "series": ["Bestsellery", "Wiedźmin"],
  "language": "polish"
}
```

`prettier --check` and `tsc --noEmit` both pass. Only the `pl` market was checked against live HTML; the selectors are shared across all markets, so the other locales should benefit the same way.

## Note, not fixed here

On the search page the cover `<img>` sits inside `<noscript>`, which parse5 treats as raw text with scripting enabled, so `match.cover` stays empty. It is harmless today because `parseBookDetails` reads the cover from the detail page. Happy to address it separately if you want covers available without the detail fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)